### PR TITLE
add enabled flag for etherpad-postgres instead of enabling it always if etherpad is enabled

### DIFF
--- a/charts/dbp-moodle/Chart.yaml
+++ b/charts/dbp-moodle/Chart.yaml
@@ -43,7 +43,7 @@ dependencies:
     version: "15.5.7"
     repository: https://charts.bitnami.com/bitnami
     alias: etherpad-postgresql
-    condition: etherpadlite.enabled
+    condition: etherpad-postgresql.enabled
 
   - name: etherpad
     version: 0.1.0

--- a/charts/dbp-moodle/README.md
+++ b/charts/dbp-moodle/README.md
@@ -126,6 +126,7 @@ The Chart can be deployed without any modification but it is advised to set own 
 | etherpad-postgresql.auth.existingSecret | string | `"moodle"` |  |
 | etherpad-postgresql.auth.secretKeys.userPasswordKey | string | `"etherpad-postgresql-password"` |  |
 | etherpad-postgresql.auth.username | string | `"etherpad"` |  |
+| etherpad-postgresql.enabled | bool | `false` |  |
 | etherpad-postgresql.persistence.existingClaim | string | `"moodle-etherpad-postgresql"` |  |
 | etherpad-postgresql.primary.affinity | object | `{}` |  |
 | etherpad-postgresql.primary.containerSecurityContext.privileged | bool | `false` |  |

--- a/charts/dbp-moodle/values.yaml
+++ b/charts/dbp-moodle/values.yaml
@@ -446,6 +446,7 @@ etherpadlite:
       memory: "1Gi"
 
 etherpad-postgresql:
+  enabled: false
   auth:
     enablePostgresUser: false
     username: etherpad


### PR DESCRIPTION
add enabled flag for etherpad-postgres instead of enabling it always if etherpad is enabled

# Description

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.