### PR TITLE
Dbp 000 hardcode names

### DIFF
--- a/charts/dbp-moodle/README.md
+++ b/charts/dbp-moodle/README.md
@@ -69,7 +69,7 @@ The Chart can be deployed without any modification but it is advised to set own 
 | backup-cronjob.extraVolumes[2].projected.sources[0].configMap.items[0].path | string | `"conf"` |  |
 | backup-cronjob.extraVolumes[2].projected.sources[0].configMap.items[1].key | string | `"exclude"` |  |
 | backup-cronjob.extraVolumes[2].projected.sources[0].configMap.items[1].path | string | `"exclude"` |  |
-| backup-cronjob.extraVolumes[2].projected.sources[0].configMap.name | string | `"moodle-duply"` |  |
+| backup-cronjob.extraVolumes[2].projected.sources[0].configMap.name | string | `"moodle-backup-duply"` |  |
 | backup-cronjob.extraVolumes[2].projected.sources[1].secret.name | string | `"moodle-backup-gpg-keys"` |  |
 | backup-cronjob.image.repository | string | `"ghcr.io/dbildungsplattform/moodle-tools"` |  |
 | backup-cronjob.image.tag | string | `"1.0.7"` |  |

--- a/charts/dbp-moodle/README.md
+++ b/charts/dbp-moodle/README.md
@@ -270,6 +270,7 @@ The Chart can be deployed without any modification but it is advised to set own 
 | moodle.podAnnotations.moodle/image | string | `"{{- .Values.image.repository -}}:{{- .Values.image.tag -}}"` |  |
 | moodle.podAnnotations.moodleplugins/checksum | string | `"{{- include \"dbpMoodle.pluginConfigMap.content\" . | sha256sum -}}"` |  |
 | moodle.podSecurityContext.enabled | bool | `true` |  |
+| moodle.readinessProbe.path | string | `"/login/index.php?noredirect=1"` |  |
 | moodle.resources.limits.cpu | int | `6` |  |
 | moodle.resources.limits.memory | string | `"3Gi"` |  |
 | moodle.resources.requests.cpu | string | `"300m"` |  |
@@ -306,7 +307,7 @@ The Chart can be deployed without any modification but it is advised to set own 
 | moodlecronjob.securityContext.privileged | bool | `false` |  |
 | moodlecronjob.securityContext.runAsGroup | int | `1001` |  |
 | moodlecronjob.serviceAccount.create | bool | `false` |  |
-| moodlecronjob.serviceAccount.name | string | `"moodle-moodle-cronjob"` |  |
+| moodlecronjob.serviceAccount.name | string | `"moodle-cronjob"` |  |
 | moodlecronjob.tolerations | list | `[]` |  |
 | postgresql.auth.database | string | `"moodle"` |  |
 | postgresql.auth.existingSecret | string | `"moodle"` |  |

--- a/charts/dbp-moodle/templates/chart-hooks/moodle-restore-job.yaml
+++ b/charts/dbp-moodle/templates/chart-hooks/moodle-restore-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-restore-job"
+  name: "moodle-restore-job"
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-upgrade
@@ -18,13 +18,13 @@ spec:
           claimName: {{ include "dbpMoodle.moodlePvc.name" . }}
       - name: moodle-restore-script
         configMap:
-          name: "{{ .Release.Name }}-restore-script"
+          name: "moodle-restore-script"
           defaultMode: 0711
       - name: duply
         projected:
           sources:
             - configMap:
-                name: "{{ .Release.Name }}-duply"
+                name: "moodle-backup-duply"
                 items:
                   - key: conf
                     path: conf
@@ -33,8 +33,8 @@ spec:
             - secret:
                 name: {{ .Values.dbpMoodle.restore.existingSecretGPG }}
           defaultMode: 0644
-      serviceAccountName: "{{ .Release.Name }}-restore-job"
-      serviceAccount: "{{ .Release.Name }}-restore-job"
+      serviceAccountName: "moodle-restore-job"
+      serviceAccount: "moodle-restore-job"
       containers:
       - name:  moodle-restore-job
         image: {{ .Values.dbpMoodle.restore.image }}

--- a/charts/dbp-moodle/templates/chart-hooks/moodle-update-preparation-job.yaml
+++ b/charts/dbp-moodle/templates/chart-hooks/moodle-update-preparation-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-update-preparation"
+  name: "moodle-update-preparation"
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "1"
@@ -33,12 +33,12 @@ spec:
             periodSeconds: 10
       affinity: {{ .Values.dbpMoodle.moodleUpdatePreparationJob.affinity | toYaml }}
       tolerations: {{ .Values.dbpMoodle.moodleUpdatePreparationJob.tolerations | toYaml }}
-      serviceAccountName: "{{ .Release.Name }}-moodle-update-preparation-hook-serviceaccount"
+      serviceAccountName: "moodle-update-preparation-hook-serviceaccount"
       restartPolicy: Never
       volumes:
         - name: script-volume
           configMap:
-            name: "{{ .Release.Name }}-moodle-update-preparation-hook-script"
+            name: "moodle-update-preparation-hook-script"
             defaultMode: 0755
   ttlSecondsAfterFinished: 300
 {{ end }}

--- a/charts/dbp-moodle/templates/configmaps/duply-configmap.yaml
+++ b/charts/dbp-moodle/templates/configmaps/duply-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-duply"
+  name: "moodle-backup-duply"
   namespace: "{{ .Release.Namespace }}"
 data:
   conf: |-

--- a/charts/dbp-moodle/templates/configmaps/moodle-backup-script-configmap.yaml
+++ b/charts/dbp-moodle/templates/configmaps/moodle-backup-script-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-backup-script
+  name: moodle-backup-script
   namespace: {{ .Release.Namespace }}
 data:
   backup-script: |-

--- a/charts/dbp-moodle/templates/configmaps/moodle-cronjob-configmap.yaml
+++ b/charts/dbp-moodle/templates/configmaps/moodle-cronjob-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-{{ include "moodlecronjob.job_name" . }}
+  name: moodle-{{ include "moodlecronjob.job_name" . }}
   namespace: {{ .Release.Namespace }}
 data:
   cronjob-script: |-

--- a/charts/dbp-moodle/templates/configmaps/moodle-restore-script-configmap.yaml
+++ b/charts/dbp-moodle/templates/configmaps/moodle-restore-script-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-restore-script
+  name: moodle-restore-script
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-upgrade

--- a/charts/dbp-moodle/templates/configmaps/moodle-update-preparation-hook-configmap.yaml
+++ b/charts/dbp-moodle/templates/configmaps/moodle-update-preparation-hook-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-moodle-update-preparation-hook-script"
+  name: "moodle-update-preparation-hook-script"
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "0"

--- a/charts/dbp-moodle/templates/hpa.yaml
+++ b/charts/dbp-moodle/templates/hpa.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ .Release.Name }}-autoscaler
+  name: moodle-autoscaler
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:

--- a/charts/dbp-moodle/templates/metrics-servicemonitor.yaml
+++ b/charts/dbp-moodle/templates/metrics-servicemonitor.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}-metrics
+  name: moodle-metrics
   namespace: {{ .Release.Namespace }}
 spec:
   endpoints:

--- a/charts/dbp-moodle/templates/rolebindings/backup-rolebinding.yaml
+++ b/charts/dbp-moodle/templates/rolebindings/backup-rolebinding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: "{{ .Release.Name }}-backup-job"
+  name: "moodle-backup-job"
 subjects:
   - kind: ServiceAccount
-    name: "{{ .Release.Name }}-backup-job"
+    name: "moodle-backup-job"
     namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: Role
-  name: "{{ .Release.Name }}-backup-job"
+  name: "moodle-backup-job"
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}

--- a/charts/dbp-moodle/templates/rolebindings/moodle-cronjob-rolebinding.yaml
+++ b/charts/dbp-moodle/templates/rolebindings/moodle-cronjob-rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: "{{ .Release.Name }}-moodle-cronjob"
+  name: "moodle-cronjob"
 subjects:
   - kind: ServiceAccount
-    name: "{{ .Release.Name }}-moodle-cronjob"
+    name: "moodle-cronjob"
     namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: Role
-  name: "{{ .Release.Name }}-moodle-cronjob"
+  name: "moodle-cronjob"
   apiGroup: rbac.authorization.k8s.io

--- a/charts/dbp-moodle/templates/rolebindings/moodle-update-preparation-hook-rolebinding.yml
+++ b/charts/dbp-moodle/templates/rolebindings/moodle-update-preparation-hook-rolebinding.yml
@@ -2,17 +2,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: "{{ .Release.Name }}-moodle-update-preparation-hook-rolebinding"
+  name: "moodle-update-preparation-hook-rolebinding"
+  namespace: "{{ .Release.Namespace }}"
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 subjects:
   - kind: ServiceAccount
-    name: "{{ .Release.Name }}-moodle-update-preparation-hook-serviceaccount"
+    name: "moodle-update-preparation-hook-serviceaccount"
     namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: Role
-  name: "{{ .Release.Name }}-moodle-update-preparation-hook-role"
+  name: "moodle-update-preparation-hook-role"
   apiGroup: rbac.authorization.k8s.io
 {{ end }}

--- a/charts/dbp-moodle/templates/rolebindings/restore-rolebinding.yaml
+++ b/charts/dbp-moodle/templates/rolebindings/restore-rolebinding.yaml
@@ -2,18 +2,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: "{{ .Release.Name }}-restore-job"
-  namespace: {{ .Release.Namespace }}
+  name: "moodle-restore-job"
+  namespace: "{{ .Release.Namespace }}"
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 subjects:
   - kind: ServiceAccount
-    name: "{{ .Release.Name }}-restore-job"
+    name: "moodle-restore-job"
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: "{{ .Release.Name }}-restore-job"
+  name: "moodle-restore-job"
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/dbp-moodle/templates/roles/backup-role.yaml
+++ b/charts/dbp-moodle/templates/roles/backup-role.yaml
@@ -2,6 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: "{{ .Release.Name }}-backup-job"
+  name: "moodle-backup-job"
 rules: {{- toYaml .Values.dbpMoodle.backup.rules | nindent 2 }}
 {{- end -}}

--- a/charts/dbp-moodle/templates/roles/moodle-cronjob-role.yaml
+++ b/charts/dbp-moodle/templates/roles/moodle-cronjob-role.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: "{{ .Release.Name }}-moodle-cronjob"
+  name: "moodle-cronjob"
 rules:
   {{- toYaml .Values.dbpMoodle.moodlecronjob.rules | nindent 2 }}

--- a/charts/dbp-moodle/templates/roles/moodle-update-preparation-hook-role.yaml
+++ b/charts/dbp-moodle/templates/roles/moodle-update-preparation-hook-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: "{{ .Release.Name }}-moodle-update-preparation-hook-role"
+  name: "moodle-update-preparation-hook-role"
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "0"

--- a/charts/dbp-moodle/templates/roles/restore-role.yaml
+++ b/charts/dbp-moodle/templates/roles/restore-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: "{{ .Release.Name }}-restore-job"
+  name: "moodle-restore-job"
   namespace: "{{ .Release.Namespace }}"
   annotations:
     "helm.sh/hook": pre-upgrade

--- a/charts/dbp-moodle/templates/serviceaccounts/backup-serviceaccount.yaml
+++ b/charts/dbp-moodle/templates/serviceaccounts/backup-serviceaccount.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{ .Release.Name }}-backup-job"
+  name: "moodle-backup-job"
   namespace: "{{ .Release.Namespace }}"
 {{- end -}}

--- a/charts/dbp-moodle/templates/serviceaccounts/moodle-cronjob-serviceaccount.yaml
+++ b/charts/dbp-moodle/templates/serviceaccounts/moodle-cronjob-serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{ .Release.Name }}-moodle-cronjob"
+  name: "moodle-cronjob"
   namespace: "{{ .Release.Namespace }}"

--- a/charts/dbp-moodle/templates/serviceaccounts/moodle-update-preparation-hook-serviceaccount.yaml
+++ b/charts/dbp-moodle/templates/serviceaccounts/moodle-update-preparation-hook-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{ .Release.Name }}-moodle-update-preparation-hook-serviceaccount"
+  name: "moodle-update-preparation-hook-serviceaccount"
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "0"

--- a/charts/dbp-moodle/templates/serviceaccounts/restore-serviceaccount.yaml
+++ b/charts/dbp-moodle/templates/serviceaccounts/restore-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{ .Release.Name }}-restore-job"
+  name: "moodle-restore-job"
   namespace: "{{ .Release.Namespace }}"
   annotations:
     "helm.sh/hook": pre-upgrade

--- a/charts/dbp-moodle/values.yaml
+++ b/charts/dbp-moodle/values.yaml
@@ -253,6 +253,8 @@ moodle:
     existingClaim: "moodle-data"
   affinity: {}
   tolerations: []
+  readinessProbe:
+    path: /login/index.php?noredirect=1
   resources:
     requests:
       cpu: 300m

--- a/charts/dbp-moodle/values.yaml
+++ b/charts/dbp-moodle/values.yaml
@@ -510,7 +510,7 @@ moodlecronjob:
   clusterRole:
     create: false
   serviceAccount:
-    name: "moodle-moodle-cronjob"
+    name: "moodle-cronjob"
     create: false
   securityContext:
     privileged: false
@@ -620,7 +620,7 @@ backup-cronjob:
       projected:
         sources:
           - configMap:
-              name: moodle-duply
+              name: moodle-backup-duply
               items:
                 - key: conf
                   path: conf


### PR DESCRIPTION
# Description
Deployment in the Dataport Rechenzentrum has shown that using Release.Name for most resources is, while possible, quite finicky and results in a slow trial and error deployment.

Switching to hardcoded names for most resources improves ease of deployment drastically, while removing the possibility of deploying multiple moodle instances per namespace. A use case which has so far only been theoretical at best.

Additional:
Change readiness Probe path from
"/login/index.php"
to
"/login/index.php?noredirect=1"
This prevents redirects, resulting in a more robust readinessProbe when SSO plugins like oidc are used and might be broken or unreachable

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.