### PR TITLE
fix(chart): DBP-2274 Default values for etherpad-db in backup-cronjob added

### DIFF
--- a/charts/dbp-moodle/CHANGELOG.md
+++ b/charts/dbp-moodle/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.3.4] - 2026-05-07
+
+### Fixed
+- **DBP-2274**: Add default chart values for the etherpad database in the backup-cronjob config.
+    - DATABASE_HOST_ETHERPAD, DATABASE_PORT_ETHERPAD, DATABASE_NAME_ETHERPAD, DATABASE_USER_ETHERPAD are all filled via the automatically created etherpad-db-secret and configured via etherpadlite.externalDatabase by default
+    - DATABASE_PASSWORD_ETHERPAD references the moodle secret and expects by default an etherpad-postgresql-password key in that secret. If this is not supported in your setup it must be adjusted by overriding the env block with the according values.
+
+
 ## [1.3.3] - 2026-04-14
 
 ### Fixed

--- a/charts/dbp-moodle/CHANGELOG.md
+++ b/charts/dbp-moodle/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Changelog
 
-## [1.3.4] - 2026-05-07
+## [1.3.4] - 2026-05-08
 
 ### Fixed
 - **DBP-2274**: Add default chart values for the etherpad database in the backup-cronjob config.
     - DATABASE_HOST_ETHERPAD, DATABASE_PORT_ETHERPAD, DATABASE_NAME_ETHERPAD, DATABASE_USER_ETHERPAD are all filled via the automatically created etherpad-db-secret and configured via etherpadlite.externalDatabase by default
     - DATABASE_PASSWORD_ETHERPAD references the moodle secret and expects by default an etherpad-postgresql-password key in that secret. If this is not supported in your setup it must be adjusted by overriding the env block with the according values.
 
+### Changed
+- Image Update
+  - Updated Moodle Image to '4.5.10-fpm-bookworm-8.2.30-dbp8'
 
 ## [1.3.3] - 2026-04-14
 

--- a/charts/dbp-moodle/Chart.yaml
+++ b/charts/dbp-moodle/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   The Chart can be deployed without any modification but it is advised to set own secrets acccording to this readme.
 type: application
 home: https://dbildungsplattform.github.io/dbp-moodle/
-version: 1.3.3
+version: 1.3.4
 appVersion: "4.5.10"
 dependencies:
   - name: moodle

--- a/charts/dbp-moodle/README.md
+++ b/charts/dbp-moodle/README.md
@@ -1,6 +1,6 @@
 # dbp-moodle
 
-![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.5.10](https://img.shields.io/badge/AppVersion-4.5.10-informational?style=flat-square)
+![Version: 1.3.4](https://img.shields.io/badge/Version-1.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.5.10](https://img.shields.io/badge/AppVersion-4.5.10-informational?style=flat-square)
 
 This is a Helm Chart bundling some of the bitnami resources to deploy Moodle for DBildungsplattform. Extending them with features such as
 PostgreSQL support, Horizontal Autoscaling capabilities, Redis Session Store, Etherpad-Lite.
@@ -31,6 +31,15 @@ The Chart can be deployed without any modification but it is advised to set own 
 | backup-cronjob.env[0].name | string | `"DATABASE_HOST"` |  |
 | backup-cronjob.env[0].valueFrom.secretKeyRef.key | string | `"host"` |  |
 | backup-cronjob.env[0].valueFrom.secretKeyRef.name | string | `"moodle-database"` |  |
+| backup-cronjob.env[10].name | string | `"AWS_ACCESS_KEY_ID"` |  |
+| backup-cronjob.env[10].valueFrom.secretKeyRef.key | string | `"s3_access_key"` |  |
+| backup-cronjob.env[10].valueFrom.secretKeyRef.name | string | `"moodle-backup-s3"` |  |
+| backup-cronjob.env[11].name | string | `"AWS_SECRET_ACCESS_KEY"` |  |
+| backup-cronjob.env[11].valueFrom.secretKeyRef.key | string | `"s3_access_secret"` |  |
+| backup-cronjob.env[11].valueFrom.secretKeyRef.name | string | `"moodle-backup-s3"` |  |
+| backup-cronjob.env[12].name | string | `"S3_BACKUP_REGION_URL"` |  |
+| backup-cronjob.env[12].valueFrom.secretKeyRef.key | string | `"s3_endpoint_url"` |  |
+| backup-cronjob.env[12].valueFrom.secretKeyRef.name | string | `"moodle-backup-s3"` |  |
 | backup-cronjob.env[1].name | string | `"DATABASE_PORT"` |  |
 | backup-cronjob.env[1].valueFrom.secretKeyRef.key | string | `"port"` |  |
 | backup-cronjob.env[1].valueFrom.secretKeyRef.name | string | `"moodle-database"` |  |
@@ -43,15 +52,21 @@ The Chart can be deployed without any modification but it is advised to set own 
 | backup-cronjob.env[4].name | string | `"DATABASE_PASSWORD"` |  |
 | backup-cronjob.env[4].valueFrom.secretKeyRef.key | string | `"mariadb-password"` |  |
 | backup-cronjob.env[4].valueFrom.secretKeyRef.name | string | `"moodle"` |  |
-| backup-cronjob.env[5].name | string | `"AWS_ACCESS_KEY_ID"` |  |
-| backup-cronjob.env[5].valueFrom.secretKeyRef.key | string | `"s3_access_key"` |  |
-| backup-cronjob.env[5].valueFrom.secretKeyRef.name | string | `"moodle-backup-s3"` |  |
-| backup-cronjob.env[6].name | string | `"AWS_SECRET_ACCESS_KEY"` |  |
-| backup-cronjob.env[6].valueFrom.secretKeyRef.key | string | `"s3_access_secret"` |  |
-| backup-cronjob.env[6].valueFrom.secretKeyRef.name | string | `"moodle-backup-s3"` |  |
-| backup-cronjob.env[7].name | string | `"S3_BACKUP_REGION_URL"` |  |
-| backup-cronjob.env[7].valueFrom.secretKeyRef.key | string | `"s3_endpoint_url"` |  |
-| backup-cronjob.env[7].valueFrom.secretKeyRef.name | string | `"moodle-backup-s3"` |  |
+| backup-cronjob.env[5].name | string | `"DATABASE_HOST_ETHERPAD"` |  |
+| backup-cronjob.env[5].valueFrom.secretKeyRef.key | string | `"host"` |  |
+| backup-cronjob.env[5].valueFrom.secretKeyRef.name | string | `"etherpad-database"` |  |
+| backup-cronjob.env[6].name | string | `"DATABASE_PORT_ETHERPAD"` |  |
+| backup-cronjob.env[6].valueFrom.secretKeyRef.key | string | `"port"` |  |
+| backup-cronjob.env[6].valueFrom.secretKeyRef.name | string | `"etherpad-database"` |  |
+| backup-cronjob.env[7].name | string | `"DATABASE_NAME_ETHERPAD"` |  |
+| backup-cronjob.env[7].valueFrom.secretKeyRef.key | string | `"name"` |  |
+| backup-cronjob.env[7].valueFrom.secretKeyRef.name | string | `"etherpad-database"` |  |
+| backup-cronjob.env[8].name | string | `"DATABASE_USER_ETHERPAD"` |  |
+| backup-cronjob.env[8].valueFrom.secretKeyRef.key | string | `"user"` |  |
+| backup-cronjob.env[8].valueFrom.secretKeyRef.name | string | `"etherpad-database"` |  |
+| backup-cronjob.env[9].name | string | `"DATABASE_PASSWORD_ETHERPAD"` |  |
+| backup-cronjob.env[9].valueFrom.secretKeyRef.key | string | `"etherpad-postgresql-password"` |  |
+| backup-cronjob.env[9].valueFrom.secretKeyRef.name | string | `"moodle"` |  |
 | backup-cronjob.extraVolumeMounts[0].mountPath | string | `"/scripts/"` |  |
 | backup-cronjob.extraVolumeMounts[0].name | string | `"moodle-backup-script"` |  |
 | backup-cronjob.extraVolumeMounts[1].mountPath | string | `"/mountData"` |  |

--- a/charts/dbp-moodle/README.md
+++ b/charts/dbp-moodle/README.md
@@ -319,7 +319,7 @@ The Chart can be deployed without any modification but it is advised to set own 
 | moodle.image.pullPolicy | string | `"Always"` |  |
 | moodle.image.registry | string | `"ghcr.io"` |  |
 | moodle.image.repository | string | `"dbildungsplattform/moodle"` |  |
-| moodle.image.tag | string | `"4.5.10-fpm-bookworm-8.2.30-dbp6"` | The dbp-moodle image which is build for this helm chart |
+| moodle.image.tag | string | `"4.5.10-fpm-bookworm-8.2.30-dbp8"` | The dbp-moodle image which is build for this helm chart |
 | moodle.ingress.annotations."cert-manager.io/cluster-issuer" | string | `"sc-cert-manager-clusterissuer-letsencrypt"` |  |
 | moodle.ingress.annotations."nginx.ingress.kubernetes.io/proxy-body-size" | string | `"200M"` |  |
 | moodle.ingress.annotations."nginx.ingress.kubernetes.io/proxy-connect-timeout" | string | `"30s"` |  |

--- a/charts/dbp-moodle/charts/moodle/Chart.yaml
+++ b/charts/dbp-moodle/charts/moodle/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
     - name: apache-exporter
       image: docker.io/lusotycoon/apache-exporter:v1.0.12
     - name: moodle
-      image: ghcr.io/dbildungsplattform/moodle:4.5.10-fpm-bookworm-8.2.30-dbp4
+      image: ghcr.io/dbildungsplattform/moodle:4.5.10-fpm-bookworm-8.2.30-dbp8
     - name: os-shell
       image: docker.io/bitnamilegacy/os-shell:12-debian-12-r50
   licenses: Apache-2.0

--- a/charts/dbp-moodle/charts/moodle/README.md
+++ b/charts/dbp-moodle/charts/moodle/README.md
@@ -66,7 +66,7 @@ Moodle(TM) LMS is an open source online Learning Management System widely used a
 | image.pullSecrets | list | `[]` |  |
 | image.registry | string | `"ghcr.io"` |  |
 | image.repository | string | `"dbildungsplattform/moodle"` |  |
-| image.tag | string | `"4.5.10-fpm-bookworm-8.2.30-dbp6"` |  |
+| image.tag | string | `"4.5.10-fpm-bookworm-8.2.30-dbp8"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.apiVersion | string | `""` |  |
 | ingress.enabled | bool | `false` |  |

--- a/charts/dbp-moodle/charts/moodle/values.yaml
+++ b/charts/dbp-moodle/charts/moodle/values.yaml
@@ -72,7 +72,7 @@ redis:
 image:
   registry: ghcr.io
   repository: dbildungsplattform/moodle
-  tag: 4.5.10-fpm-bookworm-8.2.30-dbp6
+  tag: 4.5.10-fpm-bookworm-8.2.30-dbp8
   digest: ""
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images

--- a/charts/dbp-moodle/values.yaml
+++ b/charts/dbp-moodle/values.yaml
@@ -738,6 +738,31 @@ backup-cronjob:
         secretKeyRef:
           name: moodle
           key: mariadb-password
+    - name: DATABASE_HOST_ETHERPAD
+      valueFrom: 
+        secretKeyRef:
+          name: etherpad-database
+          key: host
+    - name: DATABASE_PORT_ETHERPAD
+      valueFrom: 
+        secretKeyRef:
+          name: etherpad-database
+          key: port
+    - name: DATABASE_NAME_ETHERPAD
+      valueFrom:
+        secretKeyRef:
+          name: etherpad-database
+          key: name
+    - name: DATABASE_USER_ETHERPAD
+      valueFrom:
+        secretKeyRef:
+          name: etherpad-database
+          key: user
+    - name: DATABASE_PASSWORD_ETHERPAD
+      valueFrom:
+        secretKeyRef:
+          name: moodle
+          key: etherpad-postgresql-password
     - name: AWS_ACCESS_KEY_ID
       valueFrom:
         secretKeyRef:

--- a/charts/dbp-moodle/values.yaml
+++ b/charts/dbp-moodle/values.yaml
@@ -332,7 +332,7 @@ moodle:
     registry: "ghcr.io"
     repository: "dbildungsplattform/moodle"
     # -- The dbp-moodle image which is build for this helm chart
-    tag: "4.5.10-fpm-bookworm-8.2.30-dbp6"
+    tag: "4.5.10-fpm-bookworm-8.2.30-dbp8"
     pullPolicy: Always
     # -- Debug mode for more detailed moodle installation and log output
     debug: false


### PR DESCRIPTION
# Description
Add default chart values for the etherpad database in the backup-cronjob config.
(In the Ionos setup they were defined as default values via the group vars, s.t. the missing defaults didn't come up during the tests: https://github.com/dBildungsplattform/infra-schulcloud/blob/main/ansible/group_vars/moodle/moodle.yml#L425)

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs
https://ticketsystem.dbildungscloud.de/browse/DBP-2274
<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.