### PR TITLE
fix(config): DBP-2270 Add sslproxy to php-config

### DIFF
--- a/charts/dbp-moodle/CHANGELOG.md
+++ b/charts/dbp-moodle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+### Fix
+- **DBP-2270**: ssl-proxy
+    - Added '$CFG->sslproxy = true;' to the php-config
+    - This way moodle expects the tls-termination prior to the apache webserver and can handle it properly
+    - Solves problems where json responses were wrapped in htlm code due to errors
+
 ## [1.4.1]
 ### Fix
 - **PB-70**: Mailserver Configuration

--- a/charts/dbp-moodle/scripts/config.php
+++ b/charts/dbp-moodle/scripts/config.php
@@ -70,6 +70,8 @@ define('MDL_PERFDB' , true);
 define('MDL_PERFTOLOG' , true); // OK for production
 {{- end }}
 
+$CFG->sslproxy = true;  // tls is already terminated at ingress, so http reaches the moodle pod and behaves like an ssl-proxy.
+
 {{ if .Values.dbpMoodle.phpConfig.debug -}}
 @error_reporting(E_ALL | E_STRICT); // NOT FOR PRODUCTION SERVERS!
 @ini_set('display_errors', '1');    // NOT FOR PRODUCTION SERVERS!


### PR DESCRIPTION
# Description

Since moodle is running behind the ingress-nginx resolving the tls, moodle itself receives http requests via the service. 
Therefore we need to set `$CFG->sslproxy = true` in the php-config to accomodate, otherwise it expects htttps and throws errors which reult in behaviors described in the ticket.

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs
https://ticketsystem.dbildungscloud.de/browse/DBP-2270
<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.