### PR TITLE
fix(probes): DBP-2357 Add startup probe

### DIFF
--- a/charts/dbp-moodle/CHANGELOG.md
+++ b/charts/dbp-moodle/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fix
+- **DBP-2357**: Add startup probe
+    - Larger Instances need more time during the startup, exceeding the delay of the liveness probe
+    - This leads to pod terminations and restarts during version updates, which might lead to a corrupted state
+    - To prevent this the usage of a startup probe is introduced by default which only terminates the pod after ~20 Minutes
+    - If more time is needed this can be adjusted via `.Values.moodle.startupProbe.failureThreshold` and `.Values.moodle.startupProbe.failureThreshold.periodSeconds`
+
 ## [1.5.0]
 ### Feature
 - **DM-272**: Support for both oidc and eledia_oidc plugins

--- a/charts/dbp-moodle/README.md
+++ b/charts/dbp-moodle/README.md
@@ -352,6 +352,8 @@ The Chart can be deployed without any modification but it is advised to set own 
 | moodle.resources.requests.cpu | string | `"300m"` |  |
 | moodle.resources.requests.memory | string | `"512Mi"` |  |
 | moodle.service.type | string | `"ClusterIP"` |  |
+| moodle.startupProbe.enabled | bool | `true` |  |
+| moodle.startupProbe.failureThreshold | int | `120` |  |
 | moodle.tolerations | list | `[]` |  |
 | moodle.updateStrategy.type | string | `"RollingUpdate"` |  |
 | moodlecronjob.affinity | object | `{}` |  |

--- a/charts/dbp-moodle/values.yaml
+++ b/charts/dbp-moodle/values.yaml
@@ -465,6 +465,9 @@ moodle:
     https: 8443
   networkPolicy:
     enabled: false
+  startupProbe:
+    enabled: true
+    failureThreshold: 120
 
 postgresql:
   enabled: true


### PR DESCRIPTION
# Description
    - Larger Instances need more time during the startup, exceeding the delay of the liveness probe
    - This leads to pod terminations and restarts during version updates, which might lead to a corrupted state
    - To prevent this the usage of a startup probe is introduced by default which only terminates the pod after ~20 Minutes
    - If more time is needed this can be adjusted via `.Values.moodle.startupProbe.failureThreshold` and `.Values.moodle.startupProbe.failureThreshold.periodSeconds`
    
I suspect that this might be the underlying issue why the filtercode plugin was deactivated, because there might have been a pod restart leaving moodle in a corrupted state.

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs
https://ticketsystem.dbildungscloud.de/browse/DBP-2357
<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.