### PR TITLE
fix(plugins): DBP-2450 dynamic plugin name extraction

### DIFF
--- a/charts/dbp-moodle/CHANGELOG.md
+++ b/charts/dbp-moodle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased Changes
+### Fix
+- **DBP-2450** Plugin install logic
+    - With the switch to marketplace some vendors changed the naming convention of the plugins root directory
+    - Added additional logic to dynamically find the appropriate directory
+
 ## [1.6.2] - 2026-07-24
 ### Fix
 - **PB-161**: Change plugin source to moodle marketplace from moodle plugin directory

--- a/moodle/scripts/init/pluginCheck.sh
+++ b/moodle/scripts/init/pluginCheck.sh
@@ -39,11 +39,8 @@ cleanup() {
 # plugin sources.
 #
 # The name of the root directory inside a plugin ZIP is NOT part of any contract.
-# Plugins released to the Moodle plugins directory / Moodle Marketplace via the
-# standard GitHub release workflow are submitted as GitHub zipballs, whose root
-# directory is "<owner>-<repo>-<short-sha>" (e.g.
-# "Wunderbyte-GmbH-moodle-local_wunderbyte_table-12e6781"). Moodle core itself does
-# not rely on that name either - it renames the extracted root directory while
+# Plugins released to the Moodle Marketplace may have a different root directory name (e.g. moodle-local_wunderbyte_table-3.2.8-stable instead of wunderbyte_table). 
+# Moodle core itself does not rely on that name either - it renames the extracted root directory while
 # installing (see \core\update\code_manager::unzip_plugin_file()).
 # Therefore we locate the plugin by its version.php / component instead of guessing.
 extract_plugin() {

--- a/moodle/scripts/init/pluginCheck.sh
+++ b/moodle/scripts/init/pluginCheck.sh
@@ -3,6 +3,7 @@
 # If the PluginsFailed and UpdateFailed signal files do not exist, it will move the plugins from the image to the moodle installation.
 # This will ensure that always the most up to date plugins from the image will be used.
 set -o errexit
+set -o errtrace # required, otherwise the ERR trap is not inherited by functions
 set -o nounset
 set -o pipefail
 # set -o xtrace # Uncomment this line for debugging purposes
@@ -34,18 +35,62 @@ cleanup() {
     fi
 }
 
+# Extracts <plugin_fullname>.zip and echoes the directory that actually holds the
+# plugin sources.
+#
+# The name of the root directory inside a plugin ZIP is NOT part of any contract.
+# Plugins released to the Moodle plugins directory / Moodle Marketplace via the
+# standard GitHub release workflow are submitted as GitHub zipballs, whose root
+# directory is "<owner>-<repo>-<short-sha>" (e.g.
+# "Wunderbyte-GmbH-moodle-local_wunderbyte_table-12e6781"). Moodle core itself does
+# not rely on that name either - it renames the extracted root directory while
+# installing (see \core\update\code_manager::unzip_plugin_file()).
+# Therefore we locate the plugin by its version.php / component instead of guessing.
+extract_plugin() {
+    local plugin_fullname
+    local zip_file
+    local dest
+    local candidate
+
+    plugin_fullname="$1"
+    zip_file="${plugin_zip_path}/${plugin_fullname}.zip"
+    dest="${plugin_unzip_path}/${plugin_fullname}"
+
+    if [ ! -s "$zip_file" ]; then
+        MODULE="dbp-plugins" error "Plugin archive \"${zip_file}\" is missing or empty."
+        return 1
+    fi
+
+    rm -rf "${dest:?}"
+    mkdir -p "$dest"
+    unzip -qo "$zip_file" -d "$dest"
+
+    for candidate in "$dest" "$dest"/*; do
+        [ -d "$candidate" ] || continue
+        [ -f "${candidate}/version.php" ] || continue
+        if grep -qE "\\\$plugin->component[[:space:]]*=[[:space:]]*'${plugin_fullname}'" "${candidate}/version.php"; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+
+    MODULE="dbp-plugins" error "Could not find component ${plugin_fullname} inside \"${zip_file}\". Content: $(ls -A "$dest" | tr '\n' ' ')"
+    return 1
+}
+
 install_plugin() {
-    local plugin_name
     local plugin_fullname
     local plugin_path
+    local source_dir
 
-    plugin_name="$1"
-    plugin_fullname="$2"
-    plugin_path="$3"
+    plugin_fullname="$1"
+    plugin_path="$2"
 
-    unzip -q "${plugin_zip_path}/${plugin_fullname}.zip" -d "$plugin_unzip_path"
-    mkdir -p "${moodle_path}/${plugin_path}"
-    mv "${plugin_unzip_path}${plugin_name}" "${moodle_path}/${plugin_parent_path:?}/"
+    source_dir="$(extract_plugin "$plugin_fullname")"
+
+    mkdir -p "${moodle_path}/$(dirname "$plugin_path")"
+    rm -rf "${moodle_path:?}/${plugin_path:?}"
+    cp -a "$source_dir" "${moodle_path}/${plugin_path}"
 }
 
 uninstall_plugin() {
@@ -130,7 +175,6 @@ main() {
             fi
         fi
 
-        plugin_parent_path=$(dirname "$plugin_path")
         full_path="${moodle_path}/${plugin_path}"
 
         plugin_cur_state=false
@@ -142,17 +186,29 @@ main() {
         if [ "$plugin_target_state" = "$plugin_cur_state" ]; then
             # Check if plugin update is required due to newer version in new image
             if [ "$plugin_target_state" = true ]; then
-                installed_plugin_version="$(get_plugin_version $full_path)"
-                unzip -q "${plugin_zip_path}/${plugin_fullname}.zip" -d "$plugin_unzip_path"
-                new_plugin_path="${plugin_unzip_path}/${plugin_name}"
-                new_plugin_version="$(get_plugin_version $new_plugin_path)"
+                installed_plugin_version="$(get_plugin_version "$full_path")"
+                new_plugin_path="$(extract_plugin "$plugin_fullname")"
+                new_plugin_version="$(get_plugin_version "$new_plugin_path")"
+
+                if [ -z "$new_plugin_version" ]; then
+                    MODULE="dbp-plugins" error "Could not read version of ${plugin_fullname} from its archive. Aborting."
+                    exit 1
+                fi
+
+                # An unreadable installed version means the directory exists but does not
+                # contain a usable plugin (e.g. an empty directory left behind by a
+                # previously failed install). Treat it as "needs to be installed".
+                if [ -z "$installed_plugin_version" ]; then
+                    MODULE="dbp-plugins" info "Plugin ${plugin_name} is present but has no readable version.php. Reinstalling..."
+                    installed_plugin_version=0
+                fi
 
                 # Plugin version comparison
                 if [ "$new_plugin_version" -gt "$installed_plugin_version" ]; then
                     MODULE="dbp-plugins" info "Plugin ${plugin_name} version changed (installed version: ${installed_plugin_version}, new version: ${new_plugin_version}). Updating..."
                     rm -rf "${moodle_path:?}/${plugin_path:?}"
-                    mv "${plugin_unzip_path}${plugin_name}" "${moodle_path}/${plugin_parent_path:?}/"
-                    new_installed_plugin_version="$(get_plugin_version $full_path)"
+                    cp -a "$new_plugin_path" "${moodle_path}/${plugin_path}"
+                    new_installed_plugin_version="$(get_plugin_version "$full_path")"
                     MODULE="dbp-plugins" info "New installed plugin ${plugin_name} version: ${new_installed_plugin_version}"
                     anychange=true
                 else
@@ -165,7 +221,7 @@ main() {
         if [ "$plugin_target_state" = true ]; then
             last_installed_plugin="$full_path"
             MODULE="dbp-plugins" info "Installing plugin ${plugin_name} (${plugin_fullname}) to path \"${plugin_path}\""
-            install_plugin "$plugin_name" "$plugin_fullname" "$plugin_path"
+            install_plugin "$plugin_fullname" "$plugin_path"
             last_installed_plugin=""
             anychange=true
 

--- a/moodle/scripts/init/pluginCheck.sh
+++ b/moodle/scripts/init/pluginCheck.sh
@@ -68,7 +68,9 @@ extract_plugin() {
     for candidate in "$dest" "$dest"/*; do
         [ -d "$candidate" ] || continue
         [ -f "${candidate}/version.php" ] || continue
-        if grep -qE "\\\$plugin->component[[:space:]]*=[[:space:]]*'${plugin_fullname}'" "${candidate}/version.php"; then
+        # The component may be quoted with single or double quotes (e.g.
+        # theme_boost_magnific uses double quotes).
+        if grep -qE "\\\$plugin->component[[:space:]]*=[[:space:]]*['\"]${plugin_fullname}['\"]" "${candidate}/version.php"; then
             printf '%s' "$candidate"
             return 0
         fi

--- a/moodle/scripts/install/downloadPlugins.sh
+++ b/moodle/scripts/install/downloadPlugins.sh
@@ -69,8 +69,7 @@ check_plugin_zip() {
     fi
 
     # The root directory inside the ZIP is intentionally NOT checked here - it is not
-    # guaranteed to match the plugin directory name (GitHub zipballs use
-    # "<owner>-<repo>-<sha>"). pluginCheck.sh resolves it via version.php.
+    # guaranteed to match the plugin directory name. pluginCheck.sh resolves it via version.php.
     # No "grep -q" here: with pipefail enabled, grep -q exiting on the first match
     # kills unzip with SIGPIPE (exit 141) on large archives and fails the check.
     if ! unzip -Z1 "$plugin_zip" | grep -E '(^|/)version\.php$' > /dev/null; then

--- a/moodle/scripts/install/downloadPlugins.sh
+++ b/moodle/scripts/install/downloadPlugins.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#set -eo pipefail
+set -eo pipefail
 
 major_minor="${MOODLE_VERSION%.*}"
 plugin_index=0
@@ -52,11 +52,27 @@ moodle_plugin_list=("${plugin_dependency_list[@]}" "${plugin_list[@]}")
 
 cd /plugins || exit 1
 
-check_plugin_size() {
-    plugin_name=$1    
-    plugin_size=$(stat -c%s "/plugins/${plugin_name}.zip")
-    if [ "$plugin_size" -eq 0 ]; then
-        echo "ERROR: Moodle Plugin '$plugin_name' is empty (size 0 bytes). Possible Download error." >&2
+check_plugin_zip() {
+    plugin_name=$1
+    plugin_zip="/plugins/${plugin_name}.zip"
+
+    if [ ! -s "$plugin_zip" ]; then
+        echo "ERROR: Moodle plugin '$plugin_name' was not downloaded or is empty. Possible download error." >&2
+        exit 1
+    fi
+
+    # A ZIP that cannot be listed (e.g. an HTML error page saved as .zip) must not
+    # end up in the image either.
+    if ! unzip -tq "$plugin_zip" > /dev/null; then
+        echo "ERROR: Moodle plugin '$plugin_name' is not a valid ZIP archive." >&2
+        exit 1
+    fi
+
+    # The root directory inside the ZIP is intentionally NOT checked here - it is not
+    # guaranteed to match the plugin directory name (GitHub zipballs use
+    # "<owner>-<repo>-<sha>"). pluginCheck.sh resolves it via version.php.
+    if ! unzip -Z1 "$plugin_zip" | grep -qE '(^|/)version\.php$'; then
+        echo "ERROR: Moodle plugin '$plugin_name' contains no version.php." >&2
         exit 1
     fi
 }
@@ -97,9 +113,9 @@ for plugin in "${moodle_plugin_list[@]}"; do
         sleep 60
     fi
     php -d memory_limit=256M /usr/local/bin/moosh plugin-download -v "$major_minor" "$plugin"
-    check_plugin_size "$plugin"
+    check_plugin_zip "$plugin"
     plugin_index=$((plugin_index + 1))
 done
 
 moosh plugin-download -v 3.7 customfield_dynamic
-check_plugin_size "customfield_dynamic"
+check_plugin_zip "customfield_dynamic"

--- a/moodle/scripts/install/downloadPlugins.sh
+++ b/moodle/scripts/install/downloadPlugins.sh
@@ -13,8 +13,8 @@ plugin_dependency_list=(
 )
 
 plugin_list=(
-    # mod_booking   custom download logic from gh until it is available via marketplace/directory 
-    theme_boost_magnific
+    # mod_booking   custom download logic from gh until it is available via marketplace/directory
+    # theme_boost_magnific   custom download logic below - the marketplace metadata of its only published version is broken
     theme_boost_union
     mod_choicegroup
     mod_coursecertificate
@@ -92,6 +92,16 @@ download_oidc() {
     rm -rf dbp-moodle-plugin-oidc/
 }
 
+download_boost_magnific() {
+    # The maintainer stopped publishing new versions to the Moodle marketplace; the
+    # only remaining published version (9.6.2, requires Moodle >= 4.4) has broken
+    # supported-versions metadata ("Moodle 1.9"), so "moosh plugin-download -v 4.5"
+    # refuses it. Download that version directly instead. New releases are only
+    # distributed via https://eduardokraus.com/marketplace-plugins/plugin/theme_boost_magnific
+    curl -sSfL "https://marketplace.moodle.com/api/plugins/theme_boost_magnific/versions/2026062801/download" \
+        -o theme_boost_magnific.zip
+}
+
 download_booking() {
     target_branch="MOODLE_405_STABLE"
 
@@ -106,6 +116,8 @@ download_booking() {
 }
 
 download_oidc
+download_boost_magnific
+check_plugin_zip "theme_boost_magnific"
 #download_booking
 moosh plugin-list > /dev/null
 

--- a/moodle/scripts/install/downloadPlugins.sh
+++ b/moodle/scripts/install/downloadPlugins.sh
@@ -71,7 +71,9 @@ check_plugin_zip() {
     # The root directory inside the ZIP is intentionally NOT checked here - it is not
     # guaranteed to match the plugin directory name (GitHub zipballs use
     # "<owner>-<repo>-<sha>"). pluginCheck.sh resolves it via version.php.
-    if ! unzip -Z1 "$plugin_zip" | grep -qE '(^|/)version\.php$'; then
+    # No "grep -q" here: with pipefail enabled, grep -q exiting on the first match
+    # kills unzip with SIGPIPE (exit 141) on large archives and fails the check.
+    if ! unzip -Z1 "$plugin_zip" | grep -E '(^|/)version\.php$' > /dev/null; then
         echo "ERROR: Moodle plugin '$plugin_name' contains no version.php." >&2
         exit 1
     fi


### PR DESCRIPTION
# Description

With the new moodle marketplace some plugin vendors changed the naming convention of the plugins root directory to no longer match the frankenstyle plugin name, e.g. the Wunderbyte Table Plugin renamed the root directory from wunderbyte_table to moodle-local_wunderbyte_table-3.2.8-stable.
As we dont want to manually update the plugin name in the chart every time a new plugin version is released a more dynamic approach of extracting the directory is needed.
But some plugins have no wrapper root directory while others do, so some additional logic to dynamically find the appropriate directory is needed.
This is solved by identifying the directory where the version.php lives.

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.